### PR TITLE
Add XTTS data prep and inference utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # document-creator
+
+Web interface for converting DOCX and Markdown files. This repository also contains helper scripts for training and running a custom Coqui XTTS voice.
+
+## TTS utilities
+
+- `scripts/prep_xtts_data.py` – prepare and normalize audio data and create metadata CSVs.
+- `configs/xtts_house_en.json` – sample configuration for fine-tuning XTTS v2 on an English speaker.
+- `scripts/run_xtts.py` – small inference runner used by the `/api/tts` server route.
+
+### `/api/tts` endpoint
+
+The server exposes `POST /api/tts` which expects JSON like `{ "text": "Hello" }` and returns `{ "audio": "media/tts_123.wav" }`. It spawns the Python executable specified by `COQUI_PY` and uses `XTTS_MODEL_PATH` and `XTTS_CONFIG_PATH` to locate the fine-tuned model.

--- a/configs/xtts_house_en.json
+++ b/configs/xtts_house_en.json
@@ -1,0 +1,33 @@
+{
+  "model": "xtts_v2",
+  "run_name": "house_en_xtts",
+  "project_name": "house_voice",
+  "output_path": "runs/house_en_xtts",
+  "batch_size": 16,
+  "eval_batch_size": 16,
+  "epochs": 200,
+  "lr": 1e-4,
+  "mixed_precision": true,
+  "audio": {
+    "sample_rate": 22050,
+    "do_trim_silence": true,
+    "trim_db": 45
+  },
+  "use_phonemes": true,
+  "phonemizer": "espeak",
+  "phoneme_language": "en",
+  "datasets": [{
+    "name": "house_en",
+    "path": "data/house_en",
+    "meta_file_train": "metadata_train.csv",
+    "meta_file_val": "metadata_val.csv",
+    "language": "en"
+  }],
+  "num_loader_workers": 4,
+  "lr_scheduler": "ExponentialLR",
+  "lr_scheduler_params": { "gamma": 0.9995 },
+  "grad_clip": [5.0, 5.0],
+  "save_n_checkpoints": 5,
+  "save_best_after": 2000,
+  "run_eval": true
+}

--- a/scripts/prep_xtts_data.py
+++ b/scripts/prep_xtts_data.py
@@ -1,0 +1,111 @@
+"""Prepare dataset for XTTS fine-tuning.
+
+This script normalizes audio loudness, optionally segments long files
+using VAD from faster-whisper, and writes a metadata.csv file in the
+format required by Coqui TTS:
+
+    wavs/0001.wav|Some text here.|spk1|en
+
+Usage:
+    python scripts/prep_xtts_data.py --input-dir raw_audio \
+        --transcript-file transcripts.tsv --output-dir data/house_en
+
+The transcript file should contain lines of the form:
+    filename.wav\tThis is the spoken text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import numpy as np
+import soundfile as sf
+from pydub import AudioSegment
+
+try:
+    from faster_whisper import WhisperModel
+except ImportError:  # pragma: no cover - optional dependency
+    WhisperModel = None
+
+
+def load_transcripts(path: Path) -> List[Tuple[str, str]]:
+    entries = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            name, text = line.split("\t", 1)
+            entries.append((name, text))
+    return entries
+
+
+def normalize(segment: AudioSegment, target_dbfs: float = -20.0) -> AudioSegment:
+    change = target_dbfs - segment.dBFS
+    return segment.apply_gain(change)
+
+
+def save_audio(segment: AudioSegment, path: Path, sample_rate: int) -> None:
+    segment = segment.set_frame_rate(sample_rate).set_channels(1).set_sample_width(2)
+    segment.export(path, format="wav")
+
+
+def maybe_split(path: Path, max_len: float, model: WhisperModel | None) -> Iterable[AudioSegment]:
+    segment = AudioSegment.from_file(path)
+    if len(segment) / 1000 <= max_len or model is None:
+        yield segment
+        return
+    # Use faster-whisper VAD to find voiced regions
+    audio, sr = sf.read(path)
+    segments, _ = model.transcribe(audio, language="en", vad_filter=True)
+    for s in segments:
+        start = int(s.start * 1000)
+        end = int(s.end * 1000)
+        if (end - start) / 1000 <= max_len + 0.1:
+            yield segment[start:end]
+
+
+def main(args: argparse.Namespace) -> None:
+    input_dir = Path(args.input_dir)
+    out_dir = Path(args.output_dir)
+    wav_dir = out_dir / "wavs"
+    wav_dir.mkdir(parents=True, exist_ok=True)
+
+    transcripts = load_transcripts(Path(args.transcript_file))
+
+    model = None
+    if args.vad and WhisperModel is not None:
+        model = WhisperModel("tiny", device="cpu")
+
+    metadata_path = out_dir / "metadata.csv"
+    with metadata_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f, delimiter="|")
+        index = 1
+        for name, text in transcripts:
+            audio_path = input_dir / name
+            if not audio_path.exists():
+                print(f"Warning: missing {audio_path}")
+                continue
+            for chunk in maybe_split(audio_path, args.max_len, model):
+                chunk = normalize(chunk)
+                out_path = wav_dir / f"{index:04d}.wav"
+                save_audio(chunk, out_path, args.sample_rate)
+                writer.writerow([f"wavs/{out_path.name}", text, args.speaker, args.language])
+                index += 1
+    print(f"Wrote {index-1} clips to {metadata_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare XTTS dataset")
+    parser.add_argument("--input-dir", required=True, help="Directory with source audio files")
+    parser.add_argument("--transcript-file", required=True, help="TSV file with filename and text")
+    parser.add_argument("--output-dir", required=True, help="Output dataset directory")
+    parser.add_argument("--speaker", default="spk1", help="Speaker id")
+    parser.add_argument("--language", default="en", help="Language code")
+    parser.add_argument("--sample-rate", type=int, default=22050, help="Target sample rate")
+    parser.add_argument("--max-len", type=float, default=15.0, help="Max clip length in seconds")
+    parser.add_argument("--vad", action="store_true", help="Use VAD to split long files")
+    main(parser.parse_args())

--- a/scripts/run_xtts.py
+++ b/scripts/run_xtts.py
@@ -1,0 +1,21 @@
+import argparse
+import os
+
+from TTS.api import TTS
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run XTTS inference")
+    parser.add_argument("--text", required=True, help="Text to synthesize")
+    parser.add_argument("--out", required=True, help="Path to output wav file")
+    parser.add_argument("--model-path", required=True, help="Path to model checkpoint")
+    parser.add_argument("--config-path", required=True, help="Path to model config")
+    parser.add_argument("--language", default="en", help="Language code")
+    args = parser.parse_args()
+
+    tts = TTS(model_path=args.model_path, config_path=args.config_path, progress_bar=False)
+    tts.tts_to_file(text=args.text, language=args.language, file_path=args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.js
+++ b/server.js
@@ -5,9 +5,11 @@ const path = require('path');
 const fs = require('fs');
 
 const app = express();
+app.use(express.json());
 const upload = multer({ dest: 'uploads/' });
 
 app.use(express.static('public'));
+app.use('/media', express.static('media'));
 
 app.post('/convert', upload.single('file'), (req, res) => {
   const file = req.file;
@@ -31,6 +33,28 @@ app.post('/convert', upload.single('file'), (req, res) => {
     } else {
       res.download(outputPath, 'output.docx');
     }
+  });
+});
+
+app.post('/api/tts', (req, res) => {
+  const { text } = req.body;
+  if (!text) {
+    return res.status(400).send('Text is required');
+  }
+  const modelPath = process.env.XTTS_MODEL_PATH;
+  const configPath = process.env.XTTS_CONFIG_PATH;
+  if (!modelPath || !configPath) {
+    return res.status(500).send('Model paths not configured');
+  }
+  const outputFile = path.join('media', `tts_${Date.now()}.wav`);
+  const python = process.env.COQUI_PY || 'python3';
+  const args = ['scripts/run_xtts.py', '--text', text, '--out', outputFile, '--model-path', modelPath, '--config-path', configPath];
+  const py = spawn(python, args);
+  py.on('close', (code) => {
+    if (code !== 0) {
+      return res.status(500).send('TTS failed');
+    }
+    res.json({ audio: outputFile });
   });
 });
 


### PR DESCRIPTION
## Summary
- add script for preparing XTTS training data with optional VAD splitting
- include XTTS training config and inference runner
- extend server with `/api/tts` endpoint to call the XTTS runner

## Testing
- `python3 -m py_compile scripts/prep_xtts_data.py scripts/run_xtts.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1d9a1bd88320905b3d7665f14ab1