### PR TITLE
chore: remove obsolete bullmq scheduler

### DIFF
--- a/queues/prep.queue.js
+++ b/queues/prep.queue.js
@@ -1,8 +1,7 @@
-const { Queue, QueueScheduler, QueueEvents } = require('bullmq');
+const { Queue, QueueEvents } = require('bullmq');
 const { connection } = require('./index');
 
 const prepQueue = new Queue('prep', { connection });
-new QueueScheduler('prep', { connection });
 const prepEvents = new QueueEvents('prep', { connection });
 
 module.exports = { prepQueue, prepEvents };

--- a/queues/train.queue.js
+++ b/queues/train.queue.js
@@ -1,8 +1,7 @@
-const { Queue, QueueScheduler, QueueEvents } = require('bullmq');
+const { Queue, QueueEvents } = require('bullmq');
 const { connection } = require('./index');
 
 const trainQueue = new Queue('train', { connection });
-new QueueScheduler('train', { connection });
 const trainEvents = new QueueEvents('train', { connection });
 
 module.exports = { trainQueue, trainEvents };


### PR DESCRIPTION
## Summary
- drop deprecated QueueScheduler from BullMQ train and prep queues

## Testing
- `npm test`
- `npm start` *(fails: BullMQ: Your redis options maxRetriesPerRequest must be null.)*

------
https://chatgpt.com/codex/tasks/task_e_689a4ec602b4832096b91fa0cd7bf6ad