### PR TITLE
Use shared Redis client for BullMQ workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 PORT=3001
+# Set either REDIS_URL or REDIS_HOST/REDIS_PORT
 REDIS_URL=redis://127.0.0.1:6379
+# REDIS_HOST=127.0.0.1
+# REDIS_PORT=6379
 API_KEY=changeme
 NODE_ENV=development
 COQUI_PY=/abs/path/to/venv/bin/python

--- a/queues/index.js
+++ b/queues/index.js
@@ -1,5 +1,0 @@
-const IORedis = require('ioredis');
-
-const connection = new IORedis(process.env.REDIS_URL || 'redis://127.0.0.1:6379');
-
-module.exports = { connection };

--- a/queues/prep.queue.js
+++ b/queues/prep.queue.js
@@ -1,5 +1,5 @@
 const { Queue, QueueEvents } = require('bullmq');
-const { connection } = require('./index');
+const connection = require('./redis');
 
 const prepQueue = new Queue('prep', { connection });
 const prepEvents = new QueueEvents('prep', { connection });

--- a/queues/redis.js
+++ b/queues/redis.js
@@ -1,0 +1,24 @@
+const IORedis = require('ioredis');
+
+const redisOptionsFromUrl = () => {
+  if (process.env.REDIS_URL) {
+    // Works with redis:// and rediss:// (TLS) URLs
+    return { connectionString: process.env.REDIS_URL };
+  }
+  return {
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+  };
+};
+
+const base = redisOptionsFromUrl();
+
+const client = new IORedis({
+  ...base,
+  // REQUIRED for BullMQ blocking connections:
+  maxRetriesPerRequest: null,
+  // Recommended to avoid ready check delay in some environments:
+  enableReadyCheck: false,
+});
+
+module.exports = client;

--- a/queues/train.queue.js
+++ b/queues/train.queue.js
@@ -1,5 +1,5 @@
 const { Queue, QueueEvents } = require('bullmq');
-const { connection } = require('./index');
+const connection = require('./redis');
 
 const trainQueue = new Queue('train', { connection });
 const trainEvents = new QueueEvents('train', { connection });

--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 require('dotenv').config();
+require('./workers/train');
+require('./workers/prep');
 const express = require('express');
 const multer = require('multer');
 const { spawn } = require('child_process');

--- a/workers/prep.js
+++ b/workers/prep.js
@@ -1,5 +1,5 @@
 const { Worker } = require('bullmq');
-const { connection } = require('../queues');
+const connection = require('../queues/redis');
 const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');

--- a/workers/train.js
+++ b/workers/train.js
@@ -1,5 +1,5 @@
 const { Worker } = require('bullmq');
-const { connection } = require('../queues');
+const connection = require('../queues/redis');
 const { logger } = require('../utils/logger');
 const { spawn } = require('child_process');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- add redis helper with BullMQ connection options
- reuse shared client in queues and workers
- start train and prep workers on server startup
- document REDIS_HOST/REDIS_PORT in example env

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a524a21c88320afbd7d4a92e1e594