### PR TITLE
Gracefully handle missing Redis

### DIFF
--- a/workers/prep.js
+++ b/workers/prep.js
@@ -1,8 +1,15 @@
 const { Worker } = require('bullmq');
 const connection = require('../queues/redis');
+const { logger } = require('../utils/logger');
 const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+
+if (!connection) {
+  logger.warn('Redis connection not available, prep worker disabled');
+  module.exports = null;
+  return;
+}
 
 const worker = new Worker(
   'prep',

--- a/workers/train.js
+++ b/workers/train.js
@@ -5,6 +5,12 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+if (!connection) {
+  logger.warn('Redis connection not available, train worker disabled');
+  module.exports = null;
+  return;
+}
+
 const worker = new Worker(
   'train',
   async (job) => {


### PR DESCRIPTION
## Summary
- Add try/catch and error logging around Redis client creation
- Load queue workers and routes only when Redis is available or ENABLE_REDIS is set
- Guard workers against missing Redis connections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a5981f1a08320a31ff1ec75234273