### PR TITLE
Allow configurable sample rate in XTTS prep

### DIFF
--- a/tests/test_prep_xtts_data.py
+++ b/tests/test_prep_xtts_data.py
@@ -1,0 +1,19 @@
+import wave
+from pathlib import Path
+import sys
+import pytest
+
+pydub = pytest.importorskip('pydub')
+AudioSegment = pydub.AudioSegment
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.prep_xtts_data import save_audio
+
+
+def test_save_audio_respects_sample_rate(tmp_path):
+    seg = AudioSegment.silent(duration=1000, frame_rate=48000)
+    out = tmp_path / 'clip.wav'
+    save_audio(seg, out, sample_rate=16000)
+    with wave.open(str(out), 'rb') as f:
+        assert f.getframerate() == 16000
+        assert f.getnchannels() == 1

--- a/workers/prep.js
+++ b/workers/prep.js
@@ -28,11 +28,12 @@ const worker = new Worker(
       speaker,
       '--language',
       language,
-      '--sample-rate',
-      String(sampleRate),
       '--max-len',
       String(maxLen || 15),
     ];
+    if (typeof sampleRate === 'number') {
+      args.push('--sample-rate', String(sampleRate));
+    }
     if (vad) args.push('--vad');
 
     const logDir = path.join('logs', 'jobs');


### PR DESCRIPTION
## Summary
- add `--sample-rate` option to `prep_xtts_data.py` and use it when exporting audio
- pass sample rate to prep worker only when provided
- test that `save_audio` honors the requested sample rate

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a206d24f388320874de5ec0d448006